### PR TITLE
fix: correct Dr. Tiffany Joseph's pronouns on Refraction speakers page

### DIFF
--- a/app/(frontend)/refraction/speakers/page.tsx
+++ b/app/(frontend)/refraction/speakers/page.tsx
@@ -52,7 +52,7 @@ const speakers: Speaker[] = [
   {
     photo: tiffanyJoseph,
     name: 'Dr. Tiffany Joseph, PhD',
-    pronouns: 'he/him',
+    pronouns: 'she/her',
     title: 'Imagining a Better Healthcare System in the Face of Shifting Paradigms',
     headline: 'Sociology professor and award-winning author examining race, immigration, and healthcare access through groundbreaking research at Northeastern University.',
     bio: ' is an author, professor, and researcher of sociology and anthropology who examines race, immigration, and healthcare access. She is known for her award winning research publications and her books: Race on the Move: Brazilian Migrants and the Global Reconstruction and Not All In: Race, Immigration, and Healthcare Exclusion in the Age of Obamacare. Dr. Joseph is an associate professor of Sociology and International Affairs at Northeastern University and continues to conduct ground-breaking research in intersections between accessibility and healthcare. Joseph currently lives with her husband and two children in Massachusetts.',


### PR DESCRIPTION
## What changed

`app/(frontend)/refraction/speakers/page.tsx` — one line. Dr. Tiffany Joseph's `pronouns` field was `he/him`; it is now `she/her`.

## Why

The live `/refraction/speakers` page has been misgendering her. Her bio, in the same entry, uses she/her throughout — "She is an author", "her award winning research publications", "her husband and two children".

## Please confirm

I corrected this from the bio text, which is inference. **Pronouns are hers to state.** Someone on the events team should confirm directly with Dr. Joseph, and if she uses something else, this is a one-line follow-up.

## How I tested

Checked all seven speakers on the page; the other six already match their bios. No other pronoun mismatches exist in this file.

## Checklist
- [x] One-line diff, no unrelated changes
- [x] All other speakers audited for the same issue
- [ ] Preview deploy checked
- [ ] Pronouns confirmed with the speaker

🤖 Generated with [Claude Code](https://claude.com/claude-code)