### PR TITLE
ci: add GitHub Actions workflow and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Review from one of these owners is required on every pull request.
+# Listing people here is what makes "1 approval" mean a specific person
+# rather than anyone with write access.
+* @brandon-zau @aamogh16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel an in-flight run when the same branch is pushed again, so a stale
+# result can never land after a newer one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      # `npm ci` (not `install`) fails when package-lock.json has drifted from
+      # package.json, which is exactly what we want to hear about in CI.
+      - run: npm ci
+
+      - run: npm run type-check
+      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: npm


### PR DESCRIPTION
Roadmap **P2-3** (CI workflow) and **P3-5** (CODEOWNERS). Unblocked by #67, which added `npm test`.

## The workflow

Runs on every PR and on pushes to `main`: `npm ci` → `type-check` → `lint` → `test`. Job id is `check`, which is the status-check name to require in branch protection.

Two deliberate departures from `ops/06-cicd-pipeline.md`, both because the repo changed after that doc was written:

**No `npm run build` step, and no secrets.** Vercel's GitHub App already builds every PR, and since #66 set `ignoreBuildErrors`/`ignoreDuringBuilds` to `false`, those builds enforce type-check and lint as well. Duplicating the build here would mean adding three real Sanity credentials to GitHub (there are currently zero secrets) and making CI depend on a live external API — a Sanity outage would turn unrelated PRs red. What Vercel does *not* do is run `npm test`; that's the actual gap. The build stays gated by requiring the `Vercel` check alongside `check`.

**`node-version-file: .nvmrc`** instead of a hardcoded `20`, so the Node pin added in #66 has one source of truth.

## CODEOWNERS

`* @brandon-zau @aamogh16` — makes "1 approval" mean one of the two admins specifically, rather than anyone with write access, and lets either unblock the other.

## Next (not in this PR)

Branch protection (P2-4) gets configured after this merges — GitHub only offers a status check it has already seen run at least once. Planned as two rulesets so the bypass covers the human gate only:

| Ruleset | Rules | Bypass |
|---|---|---|
| Baseline | Require a PR · Require `check` + `Vercel` · Up-to-date branches · Block force-push/deletion | none |
| Review | Require 1 code-owner approval | `brandon-zau` |

## Test plan

- [x] Workflow YAML parses; job id `check`, triggers `pull_request` + `push`
- [x] `.nvmrc` and all three npm scripts referenced by the job exist
- [x] Locally: `npm ci`, `type-check`, `lint`, and `test` (22 passing) all green
- [ ] **The real test is this PR** — `check` must appear and pass below. A malformed workflow never runs at all, so a green `check` here is the proof.