### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,37 @@
-## What changed
+## Summary
+<!-- 1-2 sentences: what does this PR do and why does it matter? -->
 
-## Why
+## Type of change
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Refactor / chore
+- [ ] Docs
+- [ ] Config / infra (CI, deploy, tooling)
 
+## Related issue
 Closes #
 
-## Preview
+## What changed
+<!-- Bullet points > paragraphs. Call out anything non-obvious. -->
 
-<!-- Vercel preview link. Screenshots for any visual change. -->
+## Why
+<!-- The problem this solves or the motivation behind it. -->
 
-## How I tested
+## Screenshots / Preview
+<!-- Vercel preview link. Before/after screenshots for any visual change. -->
 
-## Notes for the reviewer
+## Testing
+<!-- Steps taken, not just "tested locally." Include edge cases you checked. -->
 
-<!-- Context that is not obvious from the diff, or anything you want a second opinion on. -->
+
+## Notes for the reviewer + Additional Information
+<!-- Context not obvious from the diff, or anything you want a second opinion on. -->
 
 ## Checklist
-- [ ] CI is green
+- [ ] Lint passes
+- [ ] Tests pass (unit / integration as applicable)
+- [ ] Build succeeds
 - [ ] Preview checked on mobile
 - [ ] Docs updated if behavior changed
-- [ ] No debug code left
+- [ ] No debug code / console logs left
+- [ ] No secrets or API keys committed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## What changed
+
+## Why
+
+Closes #
+
+## Preview
+
+<!-- Vercel preview link. Screenshots for any visual change. -->
+
+## How I tested
+
+## Notes for the reviewer
+
+<!-- Context that is not obvious from the diff, or anything you want a second opinion on. -->
+
+## Checklist
+- [ ] CI is green
+- [ ] Preview checked on mobile
+- [ ] Docs updated if behavior changed
+- [ ] No debug code left


### PR DESCRIPTION
## What changed

Adds `.github/pull_request_template.md`. Every new PR now opens pre-filled with the same sections in the same order.

Roadmap **P3-4**.

## Why

Reviewers currently get whatever the author decides to write. The template makes the useful information — what changed, why, how it was tested, what to look at — consistent, and puts the `Closes #` link in front of the author every time.

It also completes the review setup started in #68: CI enforces the machine checks, CODEOWNERS routes the PR to a person, and this gives that person something structured to read.

## Notes for the reviewer

One section beyond what `ops/03-code-review-standard.md` specified: **Notes for the reviewer**, for context that is not obvious from the diff. Doc 03 has been updated to match, so the spec still describes reality.

`Closes #` only does real work once P3-2 and P3-7 turn the backlog into actual issues. It is in the template now so the habit forms early.

Worth knowing: **this PR will not show the template.** GitHub reads it from the base branch, so it takes effect on the next PR after this merges.

## How I tested

- `check` passes below (this touches no code, so a red result means something unrelated broke)
- Template renders as valid markdown; the HTML comments are invisible in the PR body but visible when editing